### PR TITLE
Fix tuple return value to boolean.

### DIFF
--- a/senseapi.py
+++ b/senseapi.py
@@ -475,7 +475,7 @@ class SenseAPI:
 					@note - http://www.sense-os.nl/53?nodeId=53&selectedId=11887
 		"""
 		if self.__SenseApiCall__('/sensors/{0}/data.json'.format(sensor_id), 'POST', parameters=parameters):
-			return True, {}
+			return True
 		else:
 			self.__error__ = "api call unsuccessful"
 			return False
@@ -490,7 +490,7 @@ class SenseAPI:
 			@return (bool) - Boolean indicating whether SensorsDataPost was successful.
 		"""
 		if self.__SenseApiCall__('/sensors/data.json', 'POST', parameters=parameters):
-			return True, {}
+			return True
 		else:
 			self.__error__ = "api call unsuccessful"
 			return False


### PR DESCRIPTION
I think this is just an artifact from an earlier version...

Sensor(s)DataPost now returns a boolean (like the documentation already
stated) instead of a tuple with the first item a boolean.
