### PR TITLE
Fix #12. Set live to default for test script.

### DIFF
--- a/SenseAPITest.py
+++ b/SenseAPITest.py
@@ -75,7 +75,7 @@ Test_GroupSensorsFind           = True
 
 api = senseapi.SenseAPI()
 api.setVerbosity(True)
-api.setServer('rc')
+#api.setServer('live') #options are: live (default), rc (release candidate server), dev (development server)
 
 def run_tests ():
     if AUTHENTICATE_SESSIONID:


### PR DESCRIPTION
As the tests are the only examples available it's reasonable that user try out the tests. So I think it would be reasonable to set this to the live server by default, or provide some separate examples.

@Tubyhes Agree?
